### PR TITLE
Fix a bug which swapped 'File' and 'Edit' menus

### DIFF
--- a/KnobScripter/knob_scripter.py
+++ b/KnobScripter/knob_scripter.py
@@ -3933,5 +3933,6 @@ nuke.KnobScripterPane = KnobScripterPane
 log("KS LOADED")
 ksShortcut = "alt+z"
 addKnobScripterPanel()
-nuke.menu('Nuke').addCommand('Edit/Node/Open Floating Knob Scripter', showKnobScripter, ksShortcut)
-nuke.menu('Nuke').addCommand('Edit/Node/Update KnobScripter Context', updateContext).setVisible(False)
+m = nuke.menu("Nuke").findItem("Edit")
+m.addCommand('Node/Open Floating Knob Scripter', showKnobScripter, ksShortcut)
+m.addCommand('Node/Update KnobScripter Context', updateContext).setVisible(False)


### PR DESCRIPTION

![Screenshot](https://user-images.githubusercontent.com/4323784/75298110-7083c580-57e6-11ea-873e-e9d563c3a393.png)
On nuke 11.3v4 the File and Edit menus were being drawn in reverse order. This commit adds the same commands but retains the correct menu order.

I presume it is because this command is _finding_ the menu, whereas the original code was _declaring_ it directly.