### PR TITLE
Editor only close with escape if not panel

### DIFF
--- a/KnobScripter/ksscripteditormain.py
+++ b/KnobScripter/ksscripteditormain.py
@@ -238,7 +238,8 @@ class KSScriptEditorMain(KSScriptEditor):
 
         if type(event) == QtGui.QKeyEvent:
             if key == Qt.Key_Escape:  # Close the knobscripter...
-                self.knobScripter.close()
+                if not type( self.parent().parent() ) == nuke.KnobScripterPane:
+                    self.knobScripter.close()
             elif not ctrl and not alt and not shift and event.key() == Qt.Key_Tab:  # If only tab
                 self.placeholder = "$$"
                 # 1. Set the cursor

--- a/KnobScripter/ksscripteditormain.py
+++ b/KnobScripter/ksscripteditormain.py
@@ -548,6 +548,7 @@ class KSScriptEditorMain(KSScriptEditor):
                 self.knobScripter.current_knob_dropdown.currentIndex())
             if nuke.exists(nodeName) and knobName in nuke.toNode(nodeName).knobs():
                 run_context = "{}.{}".format(nodeName, knobName)
+                code = 'exec("""{}""")'.format(code.replace('\\', '\\\\'))
             # Run the code! Much cleaner in this way:
             nuke.runIn(run_context, code)
 

--- a/KnobScripter/script_output.py
+++ b/KnobScripter/script_output.py
@@ -45,4 +45,7 @@ class ScriptOutputWidget(QtWidgets.QTextEdit):
                 return KnobScripter.keyPressEvent(self.knobScripter, event)
             elif key in [Qt.Key_Backspace, Qt.Key_Delete]:
                 self.knobScripter.clearConsole()
+            elif key == Qt.Key_Escape:
+                if type( self.parent().parent() ) == nuke.KnobScripterPane:
+                    return
         return QtWidgets.QTextEdit.keyPressEvent(self, event)


### PR DESCRIPTION
the editor should not close on escape if it is included in a nuke panel, now it's ok