### PR TITLE
Updated QFontMetrics width to horizontalAdvance

### DIFF
--- a/KnobScripter/knob_scripter.py
+++ b/KnobScripter/knob_scripter.py
@@ -390,7 +390,7 @@ class KnobScripterWidget(QtWidgets.QDialog):
 
         if config.prefs["se_tab_spaces"] != 0:
             self.script_editor.setTabStopWidth(
-                config.prefs["se_tab_spaces"] * QtGui.QFontMetrics(config.script_editor_font).width(' '))
+                config.prefs["se_tab_spaces"] * QtGui.QFontMetrics(config.script_editor_font).horizontalAdvance(' '))
 
         # Add input and output to splitter
         self.splitter.addWidget(self.script_output)

--- a/KnobScripter/ksscripteditor.py
+++ b/KnobScripter/ksscripteditor.py
@@ -70,7 +70,7 @@ class KSScriptEditor(QtWidgets.QPlainTextEdit):
             max_num /= 10
             digits += 1
 
-        space = 7 + self.fontMetrics().width('9') * digits
+        space = 7 + self.fontMetrics().horizontalAdvance('9') * digits
         return space
 
     def updateLineNumberAreaWidth(self):


### PR DESCRIPTION
QtGui.QFontMetrics was spamming errors in Nuke 14 so I updated it's '.width' property to '.horizontalAdvance'